### PR TITLE
fix: empty layers get stop command, not clear command

### DIFF
--- a/src/lib/casparCGState.ts
+++ b/src/lib/casparCGState.ts
@@ -1202,7 +1202,7 @@ export class CasparCGState0 {
 				let newLayer: CasparCG.ILayerBase = newChannel.layers[layerKey + ''] || (new CasparCG.ILayerBase())
 				if (newLayer) {
 
-					if (!newLayer.content && oldLayer.content) {
+					if (!newLayer.content && oldLayer.content && newLayer.content !== CasparCG.LayerContentType.NOTHING) {
 
 						this.log('REMOVE ' + channelKey + '-' + layerKey + ': ' + oldLayer.content + ' | ' + newLayer.content)
 						this.log(oldLayer)


### PR DESCRIPTION
When doing a nextUp we might keep around an empty foreground. This PR fixes an issue where that empty foreground would cause the background to be cleared.