### PR TITLE
Don't resend loadbg, don't resend transition from loadbg

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -394,6 +394,77 @@ test('Loadbg a video, then play it', () => {
 	})).serialize())
 
 })
+test('Loadbg a video with a transition, then play it', () => {
+	let c = getCasparCGState()
+	initState(c.ccgState)
+
+	let cc: any
+
+	// Load a video file (paused):
+
+	let layer10: CasparCG.IEmptyLayer = {
+		content: CasparCG.LayerContentType.NOTHING,
+		media: '',
+		pauseTime: 0,
+		playing: false,
+		layerNo: 10,
+		nextUp: {
+			content: CasparCG.LayerContentType.MEDIA,
+			layerNo: 10,
+			media: new CasparCG.TransitionObject('AMB', {
+				inTransition: new CasparCG.Transition('sting', 'mask_file')
+			}),
+			auto: false
+		}
+	}
+	let channel1: CasparCG.Channel = { channelNo: 1, layers: { '10': layer10 } }
+	let targetState: CasparCG.State = { channels: { '1': channel1 } }
+
+	cc = getDiff(c, targetState)
+	expect(cc).toHaveLength(1)
+	expect(cc[0].cmds).toHaveLength(1)
+	expect(cc[0].cmds[0]).toEqual(fixCommand(new AMCP.LoadbgCommand({
+		channel: 1,
+		layer: 10,
+		auto: false,
+		clip: 'AMB',
+		transition: 'sting',
+		stingMaskFilename: 'mask_file',
+		stingDelay: 0,
+		stingOverlayFilename: '',
+		noClear: false
+	})).serialize())
+
+	// Start playing it:
+	channel1.layers['10'] = {
+		content: CasparCG.LayerContentType.MEDIA,
+		media: new CasparCG.TransitionObject('AMB', {
+			inTransition: new CasparCG.Transition('sting', 'mask_file')
+		}),
+		playing: true,
+		playTime: 1000,
+		layerNo: 10
+	}
+	cc = getDiff(c, targetState)
+	expect(cc).toHaveLength(1)
+	expect(cc[0].cmds).toHaveLength(1)
+	expect(cc[0].cmds[0]).toEqual(fixCommand(new AMCP.PlayCommand({
+		channel: 1,
+		layer: 10
+	})).serialize())
+
+	// Remove the video
+	delete channel1.layers['10']
+
+	cc = getDiff(c, targetState)
+	expect(cc).toHaveLength(1)
+	expect(cc[0].cmds).toHaveLength(1)
+	expect(cc[0].cmds[0]).toEqual(fixCommand(new AMCP.ClearCommand({
+		channel: 1,
+		layer: 10
+	})).serialize())
+
+})
 test('Play a video, stop and loadbg another video', () => {
 	let c = getCasparCGState()
 	initState(c.ccgState)

--- a/src/lib/transitionObject.ts
+++ b/src/lib/transitionObject.ts
@@ -92,7 +92,7 @@ export class Transition implements CasparCG.ITransition {
 			return {
 				transition: 'sting',
 				stingMaskFilename: this.maskFile,
-				stingDelay: this.delay * (fps || 50),
+				stingDelay: Math.round(this.delay * (fps || 50)),
 				stingOverlayFilename: this.overlayFile
 			}
 		} else {
@@ -110,7 +110,7 @@ export class Transition implements CasparCG.ITransition {
 			return [
 				'STING',
 				this.maskFile,
-				this.delay * (fps || 50),
+				Math.round(this.delay * (fps || 50)),
 				this.overlayFile
 			].join(' ')
 		} else {
@@ -125,7 +125,7 @@ export class Transition implements CasparCG.ITransition {
 
 	fromCommand (command: any, fps?: number): Transition {
 		if (command._objectParams) {
-			if (command._objectParams.type === 'sting') {
+			if (command._objectParams.transition === 'sting') {
 				this.type = 'sting'
 				if (command._objectParams.stingMaskFilename) {
 					this.maskFile = command._objectParams.stingMaskFilename


### PR DESCRIPTION
Added a test for the bug Julian was seeing and fixed it.

Loadbg a video with a transition, then play it should send a single loadbg with the transition, and then a simple play command.
Old behaviour was sending a loadbg every time and a play command with transition.