### PR TITLE
Native Route Command + small fixes around pause/resume

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "resolve"
   ],
   "dependencies": {
-    "casparcg-connection": "^4.4.0",
+    "casparcg-connection": "^4.5.0",
     "fast-clone": "^1.5.3",
     "underscore": "^1.9.1"
   },

--- a/src/lib/casparCGState.ts
+++ b/src/lib/casparCGState.ts
@@ -32,7 +32,7 @@ export class CasparCGState0 {
 
 	protected _currentStateStorage: StateObjectStorage = new StateObjectStorage()
 
-	private minTimeSincePlay: number = 0.2
+	private minTimeSincePlay: number = 50
 
 	private _currentTimeFunction: () => number
 	// private _getMediaDuration: (clip: string, channelNo: number, layerNo: number) => void

--- a/src/lib/casparCGState.ts
+++ b/src/lib/casparCGState.ts
@@ -422,6 +422,33 @@ export class CasparCGState0 {
 
 				layer.noClear = command._objectParams['noClear'] as boolean
 
+			} else if (cmdName === 'PlayRouteCommand') {
+				let layer: CF.IRouteLayer = this.ensureLayer(channel, layerNo) as CF.IRouteLayer
+
+				layer.content = CasparCG.LayerContentType.ROUTE
+
+				// layer.media = 'route'
+				layer.media = new TransitionObject('route')
+				if (command._objectParams.transition) {
+					layer.media.inTransition = new Transition().fromCommand(command, channel.fps)
+				}
+
+				// TODO: The change below has functional changes, but prevents crashes.
+				if (i.additionalLayerState && i.additionalLayerState.media && typeof(i.additionalLayerState.media) !== 'string') {
+					_.extend(layer.media, { outTransition: i.additionalLayerState.media.outTransition })
+				}
+
+				let routeChannel: any 	= command._objectParams.routeChannel
+
+				let routeLayer: any 		= command._objectParams.routeLayer
+
+				layer.route = {
+					channel: 	parseInt(routeChannel, 10),
+					layer: 		(routeLayer ? parseInt(routeLayer, 10) : null)
+				}
+
+				layer.playing = true
+				layer.playTime = null // playtime is irrelevant
 			} else if (cmdName === 'MixerAnchorCommand') {
 				setMixerState(channel, command,'anchor',['x','y'])
 			} else if (cmdName === 'MixerBlendCommand') {
@@ -476,35 +503,7 @@ export class CasparCGState0 {
 				// specials/temporary workaraounds:
 
 				let customCommand: any = command._objectParams['customCommand']
-				if (customCommand === 'route') {
-
-					let layer: CF.IRouteLayer = this.ensureLayer(channel, layerNo) as CF.IRouteLayer
-
-					layer.content = CasparCG.LayerContentType.ROUTE
-
-					// layer.media = 'route'
-					layer.media = new TransitionObject('route')
-					if (command._objectParams.transition) {
-						layer.media.inTransition = new Transition().fromCommand(command, channel.fps)
-					}
-
-					// TODO: The change below has functional changes, but prevents crashes.
-					if (i.additionalLayerState && i.additionalLayerState.media && typeof(i.additionalLayerState.media) !== 'string') {
-						_.extend(layer.media, { outTransition: i.additionalLayerState.media.outTransition })
-					}
-
-					let routeChannel: any 	= command._objectParams.routeChannel
-
-					let routeLayer: any 		= command._objectParams.routeLayer
-
-					layer.route = {
-						channel: 	parseInt(routeChannel, 10),
-						layer: 		(routeLayer ? parseInt(routeLayer, 10) : null)
-					}
-
-					layer.playing = true
-					layer.playTime = null // playtime is irrelevant
-				} else if (customCommand === 'add file') {
+				if (customCommand === 'add file') {
 
 					let layer: CF.IRecordLayer = this.ensureLayer(channel, layerNo) as CF.IRecordLayer
 
@@ -881,7 +880,9 @@ export class CasparCGState0 {
 									customCommand: 'route'
 								})
 
-								cmd = new AMCP.CustomCommand(options as any)
+								// cmd = new AMCP.CustomCommand(options as any)
+
+								cmd = new AMCP.PlayRouteCommand(_.extend(options, { route: nl.route, mode }))
 							}
 						} else if (newLayer.content === CasparCG.LayerContentType.RECORD && newLayer.media !== null) {
 							let nl: CasparCG.IRecordLayer = newLayer as CasparCG.IRecordLayer

--- a/yarn.lock
+++ b/yarn.lock
@@ -761,9 +761,9 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-casparcg-connection@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/casparcg-connection/-/casparcg-connection-4.4.0.tgz#728c9c3c24a6db3490019ea98cde672667b9c98b"
+casparcg-connection@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/casparcg-connection/-/casparcg-connection-4.5.0.tgz#c85cba1b17682337e20fe7608b83e960c77ac405"
   dependencies:
     highland "^3.0.0-beta.6"
     xml2js "^0.4.19"


### PR DESCRIPTION
This PR uses a native route command from casparcg connection instead of the previously used custom command.

This PR also introduces some small changes around the lack of supper for looping + seeking.  Fundamentally this allows all calculations to be done normally, and only prevents the actual seeking. Mostly importantly this allows looped clips to paused and resumed properly.