### PR TITLE
feat: add support for FRAMES_DELAY on route

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1543,6 +1543,15 @@ test('Play a Route', () => {
 
 	expect(cc[0].cmds[0]._objectParams.command).toEqual('PLAY 1-10 route://2-15 FRAMES_DELAY 1')
 
+	// Change the delay
+	layer10.delay = 40
+
+	cc = getDiff(c, targetState)
+	expect(cc).toHaveLength(1)
+	expect(cc[0].cmds).toHaveLength(1)
+
+	expect(cc[0].cmds[0]._objectParams.command).toEqual('PLAY 1-10 route://2-15 FRAMES_DELAY 2')
+
 	// Remove the layer
 	delete channel1.layers['10']
 

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1529,9 +1529,9 @@ test('Play a Route', () => {
 
 		route: {
 			channel: 2,
-			layer: 15,
-			framesDelay: 5
+			layer: 15
 		},
+		delay: 20,
 		playTime: null // playtime is null because it is irrelevant
 	}
 	let channel1: CasparCG.Channel = { channelNo: 1, layers: { '10': layer10 } }
@@ -1541,7 +1541,7 @@ test('Play a Route', () => {
 	expect(cc).toHaveLength(1)
 	expect(cc[0].cmds).toHaveLength(1)
 
-	expect(cc[0].cmds[0]._objectParams.command).toEqual('PLAY 1-10 route://2-15 FRAMES_DELAY 5')
+	expect(cc[0].cmds[0]._objectParams.command).toEqual('PLAY 1-10 route://2-15 FRAMES_DELAY 1')
 
 	// Remove the layer
 	delete channel1.layers['10']
@@ -1581,6 +1581,7 @@ test('Loadbg a Route, then play it', () => {
 				channel: 2,
 				layer: 15
 			},
+			delay: 100,
 			auto: false
 		},
 		playTime: null // playtime is null because it is irrelevant
@@ -1598,6 +1599,8 @@ test('Loadbg a Route, then play it', () => {
 			channel: 2,
 			layer: 15
 		},
+		channelLayout: undefined,
+		framesDelay: 5,
 		mode: undefined,
 		noClear: false
 	})).serialize())
@@ -1613,8 +1616,9 @@ test('Loadbg a Route, then play it', () => {
 		route: {
 			channel: 2,
 			layer: 15
-		}
-	}
+		},
+		delay: 100
+	} as any
 	cc = getDiff(c, targetState)
 	expect(cc).toHaveLength(1)
 	expect(cc[0].cmds).toHaveLength(1)
@@ -1624,7 +1628,8 @@ test('Loadbg a Route, then play it', () => {
 		route: {
 			channel: 2,
 			layer: 15
-		}
+		},
+		framesDelay: 5
 	})).serialize())
 
 	// Remove the layer

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1529,7 +1529,8 @@ test('Play a Route', () => {
 
 		route: {
 			channel: 2,
-			layer: 15
+			layer: 15,
+			framesDelay: 5
 		},
 		playTime: null // playtime is null because it is irrelevant
 	}
@@ -1540,7 +1541,7 @@ test('Play a Route', () => {
 	expect(cc).toHaveLength(1)
 	expect(cc[0].cmds).toHaveLength(1)
 
-	expect(cc[0].cmds[0]._objectParams.command).toEqual('PLAY 1-10 route://2-15')
+	expect(cc[0].cmds[0]._objectParams.command).toEqual('PLAY 1-10 route://2-15 FRAMES_DELAY 5')
 
 	// Remove the layer
 	delete channel1.layers['10']

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -105,6 +105,7 @@ export namespace CasparCG { // for external use
 			channel: number,
 			layer?: number | null
 			channelLayout?: string
+			framesDelay?: number
 		}
 		mode?: 'BACKGROUND' | 'NEXT'
 		playing: true

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -48,6 +48,7 @@ export namespace CasparCG { // for external use
 		length?: number	// The duration the video will be playing until freezing (or looping)
 		seek?: number // If set, the time in the video the video starts playing at
 		channelLayout?: string
+		delay?: number
 	}
 	export interface IMediaLayer extends ILayerBase {
 		content: LayerContentType.MEDIA
@@ -105,8 +106,8 @@ export namespace CasparCG { // for external use
 			channel: number,
 			layer?: number | null
 			channelLayout?: string
-			framesDelay?: number
 		}
+		delay?: number
 		mode?: 'BACKGROUND' | 'NEXT'
 		playing: true
 		playTime: null

--- a/src/lib/casparCGState.ts
+++ b/src/lib/casparCGState.ts
@@ -501,6 +501,9 @@ export class CasparCGState0 {
 					layer: 		(routeLayer ? parseInt(routeLayer, 10) : null)
 				}
 
+				layer.mode = command._objectParams.mode as ('BACKGROUND' | 'NEXT' | undefined)
+				layer.delay = command._objectParams.framesDelay ? this.frames2Time(command._objectParams.framesDelay as number, channel) : undefined
+
 				layer.playing = true
 				layer.playTime = null // playtime is irrelevant
 			} else if (cmdName === 'LoadRouteBgCommand') {
@@ -526,6 +529,9 @@ export class CasparCGState0 {
 					channel: 	parseInt(routeChannel, 10),
 					layer: 		(routeLayer ? parseInt(routeLayer, 10) : null)
 				}
+
+				layer.nextUp.delay = command._objectParams.framesDelay ? this.frames2Time(command._objectParams.framesDelay as number, channel) : undefined
+				layer.mode = command._objectParams.mode as ('BACKGROUND' | 'NEXT' | undefined)
 			} else if (cmdName === 'MixerAnchorCommand') {
 				setMixerState(channel, command,'anchor',['x','y'])
 			} else if (cmdName === 'MixerBlendCommand') {
@@ -1092,8 +1098,8 @@ export class CasparCGState0 {
 								let routeChannel: number 		= nl.route.channel
 								let routeLayer: number | null	= nl.route.layer || null
 								let mode = nl.mode
-								let framesDelay: number | null = nl.route.framesDelay || null
-								let diffMediaFromBg = !olNext || !olNext.route ? true : !(nl.route.channel === olNext.route.channel && nl.route.layer === olNext.route.layer)
+								let framesDelay: number | undefined = nl.delay ? Math.floor(this.time2Frames(nl.delay, newChannel, oldChannel) / 1000) : undefined
+								let diffMediaFromBg = !olNext || !olNext.route ? true : !(nl.route.channel === olNext.route.channel && nl.route.layer === olNext.route.layer && nl.delay === olNext.delay)
 
 								if (diffMediaFromBg) {
 									_.extend(options,{
@@ -1390,7 +1396,7 @@ export class CasparCGState0 {
 										route: layer.route,
 										mode: layer.mode,
 										channelLayout: layer.route ? layer.route.channelLayout : undefined,
-										framesDelay: layer.route ? layer.route.framesDelay : undefined
+										framesDelay: layer.delay ? Math.floor(this.time2Frames(layer.delay, newChannel, oldChannel) / 1000) : undefined
 									})),
 									`Nextup Route (${layer.route})`,
 									newLayer

--- a/src/lib/casparCGState.ts
+++ b/src/lib/casparCGState.ts
@@ -1092,6 +1092,7 @@ export class CasparCGState0 {
 								let routeChannel: number 		= nl.route.channel
 								let routeLayer: number | null	= nl.route.layer || null
 								let mode = nl.mode
+								let framesDelay: number | null = nl.route.framesDelay || null
 								let diffMediaFromBg = !olNext || !olNext.route ? true : !(nl.route.channel === olNext.route.channel && nl.route.layer === olNext.route.layer)
 
 								if (diffMediaFromBg) {
@@ -1105,6 +1106,7 @@ export class CasparCGState0 {
 												routeChannel +
 												(routeLayer ? '-' + routeLayer : '') +
 											(mode ? ' ' + mode : '') +
+											(framesDelay ? ' FRAMES_DELAY ' + framesDelay : '') +
 											(
 												options.transition
 												? (' ' + new Transition().fromCommand({ _objectParams: options }, oldChannel.fps).getString(oldChannel.fps))
@@ -1117,7 +1119,7 @@ export class CasparCGState0 {
 									// cmd = new AMCP.CustomCommand(options as any)
 
 									cmd = this.addContext(
-										new AMCP.PlayRouteCommand(_.extend(options, { route: nl.route, mode, channelLayout: nl.route.channelLayout })),
+										new AMCP.PlayRouteCommand(_.extend(options, { route: nl.route, mode, channelLayout: nl.route.channelLayout, framesDelay })),
 										`Route: diffMediaFromBg (${diff})`,
 										nl
 									)
@@ -1387,7 +1389,8 @@ export class CasparCGState0 {
 									new AMCP.LoadRouteBgCommand(_.extend(options, {
 										route: layer.route,
 										mode: layer.mode,
-										channelLayout: layer.route ? layer.route.channelLayout : undefined
+										channelLayout: layer.route ? layer.route.channelLayout : undefined,
+										framesDelay: layer.route ? layer.route.framesDelay : undefined
 									})),
 									`Nextup Route (${layer.route})`,
 									newLayer

--- a/src/lib/casparCGState.ts
+++ b/src/lib/casparCGState.ts
@@ -502,7 +502,7 @@ export class CasparCGState0 {
 				}
 
 				layer.mode = command._objectParams.mode as ('BACKGROUND' | 'NEXT' | undefined)
-				layer.delay = command._objectParams.framesDelay ? this.frames2Time(command._objectParams.framesDelay as number, channel) : undefined
+				layer.delay = command._objectParams.framesDelay ? this.frames2Time(command._objectParams.framesDelay as number, channel) * 1000 : undefined
 
 				layer.playing = true
 				layer.playTime = null // playtime is irrelevant
@@ -841,6 +841,7 @@ export class CasparCGState0 {
 							setDefaultValue([nl.route, ol.route], ['channel','layer'], 0)
 
 							diff = this.compareAttrs(nl.route, ol.route,['channel','layer','channelLayout'])
+							if (!diff) diff = this.compareAttrs(nl, ol, ['delay'])
 
 						} else if (newLayer.content === CasparCG.LayerContentType.RECORD) {
 							let nl: CasparCG.IRecordLayer = newLayer as CasparCG.IRecordLayer


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces support for FRAMES_DELAY parameter on Routes


* **What is the current behavior?** (You can also link to an open issue here)
It's impossible to have a route with a FRAMES_DELAY parameter.


* **What is the new behavior (if this is a feature change)?**
It is possible to specify a framesDelay parameter on the CasparCG state.


* **Other information**:
