### PR TITLE
feat: clear_on_404 parameter for PLAY/LOAD/LOADBG

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "resolve"
   ],
   "dependencies": {
-    "casparcg-connection": "^4.7.0",
+    "casparcg-connection": "^4.9.0",
     "fast-clone": "^1.5.13",
     "underscore": "^1.9.1"
   },

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -63,6 +63,7 @@ export namespace CasparCG { // for external use
 		pauseTime?: number | null
 
 		channelLayout?: string
+		clearOn404?: boolean
 
 		nextUp?: NextUp | null
 	}

--- a/src/lib/casparCGState.ts
+++ b/src/lib/casparCGState.ts
@@ -950,7 +950,8 @@ export class CasparCGState0 {
 												seek: seek,
 												length: length || undefined,
 												loop: !!nl.looping,
-												channelLayout: nl.channelLayout
+												channelLayout: nl.channelLayout,
+												clearOn404: nl.clearOn404
 											}))),
 											context,
 											nl
@@ -1015,19 +1016,29 @@ export class CasparCGState0 {
 										nl
 									)
 								} else {
-									cmd = this.addContext(
-										new AMCP.LoadCommand(_.extend(options,{
-											clip: (nl.media || '').toString(),
-											seek: seek,
-											length: length || undefined,
-											loop: !!nl.looping,
 
-											pauseTime: nl.pauseTime,
-											channelLayout: nl.channelLayout
-										})),
-										`Load / Pause otherwise (${diff})`,
-										nl
-									)
+									if (diffMediaFromBg) {
+										cmd = this.addContext(
+											new AMCP.LoadCommand(_.extend(options,{
+												clip: (nl.media || '').toString(),
+												seek: seek,
+												length: length || undefined,
+												loop: !!nl.looping,
+
+												pauseTime: nl.pauseTime,
+												channelLayout: nl.channelLayout,
+												clearOn404: nl.clearOn404
+											})),
+											`Load / Pause otherwise (${diff})`,
+											nl
+										)
+									} else {
+										cmd = this.addContext(
+											new AMCP.LoadCommand({ ...options }),
+											`No Media diff from bg (${nl.media})`,
+											nl
+										)
+									}
 
 								}
 							}
@@ -1320,7 +1331,7 @@ export class CasparCGState0 {
 
 							// make sure the layer is empty before trying to load something new
 							// this prevents weird behaviour when files don't load correctly
-							if (oldLayer.nextUp) {
+							if (oldLayer.nextUp && !(oldLayer.nextUp as CasparCG.IMediaLayer).clearOn404) {
 								additionalCmds.push(this.addContext(
 									new AMCP.LoadbgCommand({
 										channel: newChannel.channelNo,
@@ -1353,7 +1364,8 @@ export class CasparCGState0 {
 										seek: seek,
 										length: length || undefined,
 										loop: !!looping,
-										channelLayout: channelLayout
+										channelLayout: channelLayout,
+										clearOn404: layer.clearOn404
 									}))),
 									`Nextup media (${newLayer.nextUp.media})`,
 									newLayer

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,10 +893,10 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-casparcg-connection@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/casparcg-connection/-/casparcg-connection-4.7.0.tgz#c2aa4b5b5a89b17bffac77f592627aca8ec3537e"
-  integrity sha512-SQW7eiDRKiI2X/6bJACupX8TBt79JGPxCzmcIc+K3EPv/DU1uV6gmKM2pjwvQvBkXrtX+6ruijS6QbtFVzVt3w==
+casparcg-connection@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/casparcg-connection/-/casparcg-connection-4.9.0.tgz#1fb19e091ff785d312f52ed065c4077dbe55196c"
+  integrity sha512-K2c38+6RB4Agb116q4WapmZQSDAz95nlijgndpG2sYEX9lxHRJmBrJ+uysxrgJT/dXYlPGrEx++pEqwRpXPtLA==
   dependencies:
     highland "^3.0.0-beta.6"
     xml2js "^0.4.19"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add support for CLEAR_ON_404 parameter.
This removed the `LOADBG EMPTY` done before any LOADBG, with the intention that the behaviour should be enabled when wanted by TSR with the CLEAR_ON_404 parameter