### PR TITLE
fix: state mutations when nextUp routes change

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1564,6 +1564,76 @@ test('Play a Route', () => {
 	})).serialize())
 
 })
+test('Loadbg a Route, then change it', () => {
+	let c = getCasparCGState()
+	initState(c)
+
+	let cc: any
+
+	// Play a template file:
+
+	let layer10: CasparCG.IEmptyLayer = {
+		id: 'e0',
+		content: CasparCG.LayerContentType.NOTHING,
+		media: '',
+		pauseTime: 0,
+		playing: false,
+		layerNo: 10,
+		nextUp: {
+			id: 'n0',
+			content: CasparCG.LayerContentType.ROUTE,
+			layerNo: 10,
+			media: 'route',
+
+			route: {
+				channel: 2,
+				layer: 15
+			},
+			auto: false
+		},
+		playTime: null // playtime is null because it is irrelevant
+	}
+	let channel1: CasparCG.Channel = { channelNo: 1, layers: { '10': layer10 } }
+	let targetState: CasparCG.State = { channels: { '1': channel1 } }
+
+	cc = getDiff(c, targetState)
+	expect(cc).toHaveLength(1)
+	expect(cc[0].cmds).toHaveLength(1)
+	expect(stripContext(cc[0].cmds[0])).toEqual(fixCommand(new AMCP.LoadRouteBgCommand({
+		channel: 1,
+		layer: 10,
+		route: {
+			channel: 2,
+			layer: 15
+		},
+		channelLayout: undefined,
+		mode: undefined,
+		noClear: false
+	})).serialize())
+
+	expect(c.ccgState.getState().channels['1'].layers['10'].nextUp).toBeTruthy()
+	expect(c.ccgState.getState().channels['1'].layers['10'].nextUp!.route).toMatchObject({
+		channel: 2,
+		layer: 15
+	});
+
+	(layer10.nextUp!.route as any).layer = 20
+
+	cc = getDiff(c, targetState)
+	expect(cc).toHaveLength(1)
+	expect(cc[0].cmds).toHaveLength(1)
+	expect(stripContext(cc[0].cmds[0])).toEqual(fixCommand(new AMCP.LoadRouteBgCommand({
+		channel: 1,
+		layer: 10,
+		route: {
+			channel: 2,
+			layer: 20
+		},
+		channelLayout: undefined,
+		mode: undefined,
+		noClear: false
+	})).serialize())
+})
 test('Loadbg a Route, then play it', () => {
 	let c = getCasparCGState()
 	initState(c)

--- a/src/lib/casparCGState.ts
+++ b/src/lib/casparCGState.ts
@@ -1307,14 +1307,23 @@ export class CasparCGState0 {
 					let bgDiff = this.compareAttrs(newLayer.nextUp, oldLayer.nextUp, ['content'])
 					let noClear = false
 					if (!bgDiff && newLayer.nextUp) {
-						if (newLayer.nextUp.content === CasparCG.LayerContentType.MEDIA) {
+						if ((newLayer.nextUp.content === CasparCG.LayerContentType.MEDIA) ||
+							(newLayer.nextUp.content === CasparCG.LayerContentType.INPUT) ||
+							(newLayer.nextUp.content === CasparCG.LayerContentType.HTMLPAGE) ||
+							(newLayer.nextUp.content === CasparCG.LayerContentType.ROUTE)) {
+							let nl: CasparCG.IMediaLayer = newLayer.nextUp as any
+							let ol: CF.IMediaLayer = oldLayer.nextUp as any
+							setDefaultValue([nl, ol], ['auto'], false)
+							bgDiff = this.compareAttrs(nl, ol ,['auto','channelLayout'])
+						}
+
+						if (!bgDiff && newLayer.nextUp.content === CasparCG.LayerContentType.MEDIA) {
 							let nl: CasparCG.IMediaLayer = newLayer.nextUp as CasparCG.IMediaLayer
 							let ol: CF.IMediaLayer = oldLayer.nextUp as CF.IMediaLayer
 
 							setDefaultValue([nl, ol], ['seek', 'length', 'inPoint'], 0)
-							setDefaultValue([nl, ol], ['auto'], false)
 
-							bgDiff = this.compareAttrs(nl, ol ,['media','seek','length','inPoint','auto','channelLayout'])
+							bgDiff = this.compareAttrs(nl, ol ,['media','seek','length','inPoint'])
 						}
 
 						if (!bgDiff && newLayer.nextUp && oldLayer.nextUp && (typeof newLayer.nextUp.media !== 'string' || typeof oldLayer.nextUp.media !== 'string')) {
@@ -1329,11 +1338,6 @@ export class CasparCGState0 {
 							let oRoute = oldLayer.nextUp.route
 
 							bgDiff = this.compareAttrs(nRoute, oRoute, ['channel', 'layer'])
-
-							if (!bgDiff) {
-								setDefaultValue([newLayer.nextUp, oldLayer.nextUp], ['auto'], false)
-								bgDiff = this.compareAttrs(newLayer.nextUp, oldLayer.nextUp, ['auto'])
-							}
 
 							if (bgDiff) noClear = true
 						}

--- a/src/lib/casparCGState.ts
+++ b/src/lib/casparCGState.ts
@@ -525,7 +525,7 @@ export class CasparCGState0 {
 					routeLayer = route.layer
 				}
 
-				layer.route = {
+				layer.nextUp.route = {
 					channel: 	parseInt(routeChannel, 10),
 					layer: 		(routeLayer ? parseInt(routeLayer, 10) : null)
 				}
@@ -1305,6 +1305,7 @@ export class CasparCGState0 {
 					// console.log('oldLayer', oldLayer.nextUp)
 					// console.log('newLayer', newLayer.nextUp)
 					let bgDiff = this.compareAttrs(newLayer.nextUp, oldLayer.nextUp, ['content'])
+					let noClear = false
 					if (!bgDiff && newLayer.nextUp) {
 						if (newLayer.nextUp.content === CasparCG.LayerContentType.MEDIA) {
 							let nl: CasparCG.IMediaLayer = newLayer.nextUp as CasparCG.IMediaLayer
@@ -1321,6 +1322,20 @@ export class CasparCGState0 {
 							let ol = oldLayer.nextUp.media
 
 							bgDiff = this.compareAttrs(nl, ol ,['inTransition','outTransition','changeTransition'])
+						}
+
+						if (!bgDiff && newLayer.nextUp && newLayer.nextUp.route && oldLayer.nextUp && oldLayer.nextUp.route) {
+							let nl = newLayer.nextUp.route
+							let ol = oldLayer.nextUp.route
+
+							bgDiff = this.compareAttrs(nl, ol, ['channel', 'layer'])
+
+							if (!bgDiff) {
+								setDefaultValue([newLayer.nextUp, oldLayer.nextUp], ['auto'], false)
+								bgDiff = this.compareAttrs(newLayer.nextUp, oldLayer.nextUp, ['auto'])
+							}
+
+							if (bgDiff) noClear = true
 						}
 
 						// @todo: should this be a flag set during the generation of the commands for the foreground layer? /Balte
@@ -1340,7 +1355,7 @@ export class CasparCGState0 {
 
 							// make sure the layer is empty before trying to load something new
 							// this prevents weird behaviour when files don't load correctly
-							if (oldLayer.nextUp && !(oldLayer.nextUp as CasparCG.IMediaLayer).clearOn404) {
+							if (oldLayer.nextUp && !(oldLayer.nextUp as CasparCG.IMediaLayer).clearOn404 && !noClear) {
 								additionalCmds.push(this.addContext(
 									new AMCP.LoadbgCommand({
 										channel: newChannel.channelNo,

--- a/src/lib/casparCGState.ts
+++ b/src/lib/casparCGState.ts
@@ -1318,17 +1318,17 @@ export class CasparCGState0 {
 						}
 
 						if (!bgDiff && newLayer.nextUp && oldLayer.nextUp && (typeof newLayer.nextUp.media !== 'string' || typeof oldLayer.nextUp.media !== 'string')) {
-							let nl = newLayer.nextUp.media
-							let ol = oldLayer.nextUp.media
+							let nMedia = newLayer.nextUp.media
+							let oMedia = oldLayer.nextUp.media
 
-							bgDiff = this.compareAttrs(nl, ol ,['inTransition','outTransition','changeTransition'])
+							bgDiff = this.compareAttrs(nMedia, oMedia ,['inTransition','outTransition','changeTransition'])
 						}
 
 						if (!bgDiff && newLayer.nextUp && newLayer.nextUp.route && oldLayer.nextUp && oldLayer.nextUp.route) {
-							let nl = newLayer.nextUp.route
-							let ol = oldLayer.nextUp.route
+							let nRoute = newLayer.nextUp.route
+							let oRoute = oldLayer.nextUp.route
 
-							bgDiff = this.compareAttrs(nl, ol, ['channel', 'layer'])
+							bgDiff = this.compareAttrs(nRoute, oRoute, ['channel', 'layer'])
 
 							if (!bgDiff) {
 								setDefaultValue([newLayer.nextUp, oldLayer.nextUp], ['auto'], false)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

If a `nextUp` object on a route changes, the changes will not be represented in the internal state and commands will not be issued.

* **What is the new behavior (if this is a feature change)?**

`nextUp` route changes affect state correctly and issue `LOADBG` commands.

* **Other information**:
