### PR TITLE
bug: Comparing the playTime property between states results in command resend with the retry timer in TSR

### DIFF
--- a/src/lib/casparCGState.ts
+++ b/src/lib/casparCGState.ts
@@ -1990,6 +1990,7 @@ export class CasparCGState0 {
 		let cmp = (a: any, b: any, name: any) => {
 
 			if (name === 'playTime') {
+				if (!a) return false
 				return Math.abs(a - b) > this.minTimeSincePlay
 			} else {
 				return !_.isEqual(a, b)


### PR DESCRIPTION
When using the retry commands feature in TSR, some objects (such as sound beds) will restart every time the timer fires. This is because when the target state and previous state are diffed, the playTime property doesn't exist on the target state.

This PR checks if playTime is present in the new state, if not, it reports that there is no difference between the states.