### PR TITLE
fix: route mode compare

### DIFF
--- a/src/lib/casparCGState.ts
+++ b/src/lib/casparCGState.ts
@@ -842,6 +842,7 @@ export class CasparCGState0 {
 
 							diff = this.compareAttrs(nl.route, ol.route,['channel','layer','channelLayout'])
 							if (!diff) diff = this.compareAttrs(nl, ol, ['delay'])
+							if (!diff) diff = this.compareAttrs(nl, ol, ['mode'])
 
 						} else if (newLayer.content === CasparCG.LayerContentType.RECORD) {
 							let nl: CasparCG.IRecordLayer = newLayer as CasparCG.IRecordLayer
@@ -1852,6 +1853,9 @@ export class CasparCGState0 {
 	// 		}
 	// 	}
 	// }
+	/**
+	 * Convert frames into time in seconds
+	 */
 	private frames2Time (
 		frames: number,
 		newChannel: CasparCG.Channel,
@@ -1859,12 +1863,15 @@ export class CasparCGState0 {
 	): number {
 		return frames / ((newChannel.fps || (oldChannel ? oldChannel.fps : 0)) || 50)
 	}
+	/**
+	 * Convert time in seconds into frames
+	 */
 	private time2Frames (
-		frames: number,
+		time: number,
 		newChannel: CasparCG.Channel,
 		oldChannel?: CasparCG.Channel
 	): number {
-		return Math.floor(frames * ((newChannel.fps || (oldChannel ? oldChannel.fps : 0)) || 0))
+		return Math.floor(time * ((newChannel.fps || (oldChannel ? oldChannel.fps : 0)) || 0))
 	}
 	private calculateSeek (
 		newChannel: CasparCG.Channel,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR fixes a problem wherein a change in ROUTE mode wouldn't cause a new command to be issued.

* **What is the current behavior?** (You can also link to an open issue here)

ROUTE mode isn't checked for when doing the state diff.

* **What is the new behavior (if this is a feature change)?**

ROUTE mode is now checked when doing the state diff between new and old layer state.
