### PR TITLE
chore: add failing test

### DIFF
--- a/src/__tests__/mixer.spec.ts
+++ b/src/__tests__/mixer.spec.ts
@@ -6,7 +6,8 @@ import {
 	EmptyLayer,
 	Channel,
 	LayerContentType,
-	LayerBase
+	LayerBase,
+	TransitionObject
 } from '../'
 import { InternalLayer } from '../lib/stateObjectStorage'
 import { AMCP, Command as CommandNS, Enum as CCGEnum } from 'casparcg-connection'
@@ -469,6 +470,65 @@ describe('MixerCommands', () => {
 				channel: 1,
 				layer: 10,
 				volume: 0.45
+			}),
+			new AMCP.MixerVolumeCommand({
+				channel: 1,
+				layer: 10,
+				volume: 1,
+				_defaultOptions: true
+			})
+		)
+	})
+	test('Mixer with transition', () => {
+		// Mixer effect on layer
+		testMixerEffect(
+			c,
+			targetState,
+			layer10,
+			{
+				changeTransition: {
+					type: 'mix',
+					duration: 1000 // ms
+				},
+				volume: 0.92
+			},
+			new AMCP.MixerVolumeCommand({
+				channel: 1,
+				layer: 10,
+				volume: 0.92,
+				transition: 'mix',
+				transitionDirection: 'right', // default value
+				transitionDuration: 25, // frames
+				transitionEasing: 'linear' // default value
+			}),
+			new AMCP.MixerVolumeCommand({
+				channel: 1,
+				layer: 10,
+				volume: 1,
+				_defaultOptions: true
+			})
+		)
+		// Mixer effect on property
+		testMixerEffect(
+			c,
+			targetState,
+			layer10,
+			{
+				volume: new TransitionObject(0.92, {
+					changeTransition: {
+						type: 'mix',
+						duration: 1000 // ms
+					}
+				})
+			},
+			new AMCP.MixerVolumeCommand({
+				channel: 1,
+				layer: 10,
+				volume: 0.92,
+				transition: 'mix',
+				transitionDirection: 'right', // default value
+				transitionDuration: 25, // frames
+				transitionEasing: 'linear' // default value
 			}),
 			new AMCP.MixerVolumeCommand({
 				channel: 1,


### PR DESCRIPTION
This PR adds a test to highlight a bug in casparcg-state.

I haven't dived too deep into the code, but it looks like we currently only support transitions on the "layer level", not transitions on the "property-level".

Due to the transition-bug which is still present in CasparCG (the one about "not being able to control multiple transitions independently"), we practically can't (reliably) control transitions on individual properties anyway.
I propose that the typings should be changed to only allow transitions on the layer level, but would like some discussion before continuing forward.

## Proposal
**Allowed**
```
{
  "layer0": {
    {
      changeTransition: {
      type: 'mix',
      duration: 1000 // ms
      },
      volume: 0.92
    },
  }
}
```
**Not allowed**
```
{
  "layer0": {
    {
      volume: new TransitionObject(0.92, {
        changeTransition: {
          type: 'mix',
          duration: 1000 // ms
        }
      })
    },
  }
}
```
