### PR TITLE
fix: add customOptions property

### DIFF
--- a/src/__tests__/mixer.spec.ts
+++ b/src/__tests__/mixer.spec.ts
@@ -478,6 +478,44 @@ describe('MixerCommands', () => {
 			})
 		)
 	})
+	test('Mixer Other transition type', () => {
+		testMixerEffect(
+			c,
+			targetState,
+			layer10,
+			{
+				changeTransition: {
+					type: 'other',
+					customOptions: {
+						blob0: 'data-blob',
+						blob1: { test: 'this is another blob' }
+					}
+				},
+				volume: 0.48
+			},
+			new AMCP.MixerVolumeCommand({
+				channel: 1,
+				layer: 10,
+				volume: 0.48,
+				transition: 'other',
+				transitionDirection: 'right', // default value
+				transitionDuration: 0, // default
+				transitionEasing: 'linear', // default value
+
+				// Thie customOptions data is passed through into the command:
+				customOptions: {
+					blob0: 'data-blob',
+					blob1: { test: 'this is another blob' }
+				}
+			}),
+			new AMCP.MixerVolumeCommand({
+				channel: 1,
+				layer: 10,
+				volume: 1,
+				_defaultOptions: true
+			})
+		)
+	})
 })
 
 function testMixerEffect(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -237,5 +237,7 @@ export interface TransitionOptions {
 	overlayFile?: string
 	audioFadeStart?: number
 	audioFadeDuration?: number
+
+	customOptions?: any // used to pipe any data blob through to the command
 }
 export { TransitionObject, Transition }

--- a/src/lib/transitionObject.ts
+++ b/src/lib/transitionObject.ts
@@ -53,6 +53,8 @@ export class Transition implements TransitionOptions {
 	audioFadeStart = 0
 	audioFadeDuration = 0
 
+	customOptions: any = undefined
+
 	constructor(
 		typeOrTransition?: string | object,
 		durationOrMaskFile?: number | string,
@@ -74,6 +76,8 @@ export class Transition implements TransitionOptions {
 			directionOrOverlayFile = isSting ? t.overlayFile : t.direction
 			audioFadeStart = isSting ? t.audioFadeStart : undefined
 			audioFadeDuration = isSting ? t.audioFadeDuration : undefined
+
+			this.customOptions = t.customOptions
 		} else {
 			type = typeOrTransition as string
 		}
@@ -136,12 +140,14 @@ export class Transition implements TransitionOptions {
 				stingOverlayFilename: this.overlayFile
 			}
 		} else {
-			return {
+			const o: any = {
 				transition: this.type,
 				transitionDuration: this.time2Frames(this.duration || 0, fps),
 				transitionEasing: this.easing,
 				transitionDirection: this.direction
 			}
+			if (this.customOptions) o['customOptions'] = this.customOptions
+			return o
 		}
 	}
 


### PR DESCRIPTION


This can be used by external users to still use the state library while utilizing "unsupported" transition types.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
-


* **What is the new behavior (if this is a feature change)?**
Add customOptions property on transitions, for pass-through of any data to the resulting command.
This can be used by for example TSR to pass through data for its internal transitions-handling.


* **Other information**:
