### PR TITLE
feat: MediaPlayer playbackId property

### DIFF
--- a/src/__tests__/playback.spec.ts
+++ b/src/__tests__/playback.spec.ts
@@ -1158,3 +1158,60 @@ test('Play a Decklink-input with transition, then stop it with transition', () =
 		}).serialize()
 	)
 })
+
+test('Play a video, then play the same one again', () => {
+	const c = getCasparCGState()
+	initState(c)
+
+	let cc: ReturnType<typeof getDiff>
+	// Play a video file:
+	const layer10: MediaLayer = {
+		id: 'l0',
+		content: LayerContentType.MEDIA,
+		layerNo: 10,
+		media: 'AMB',
+		playbackId: '1',
+		playing: true,
+		playTime: 1000,
+		seek: 0
+	}
+	const channel1: Channel = { channelNo: 1, layers: { '10': layer10 } }
+	const targetState: State = { channels: { '1': channel1 } }
+	cc = getDiff(c, targetState)
+	expect(cc).toHaveLength(1)
+	expect(cc[0].cmds).toHaveLength(1)
+	expect(stripContext(stripContext(cc[0].cmds[0]))).toEqual(
+		fixCommand(
+			new AMCP.PlayCommand({
+				channel: 1,
+				layer: 10,
+				clip: 'AMB',
+				loop: false,
+				seek: 0
+			})
+		).serialize()
+	)
+
+	// Play the same file again
+	const clip2 = {
+		...layer10,
+		id: 'l1',
+		playbackId: '2'
+	}
+	channel1.layers['10'] = clip2
+
+	cc = getDiff(c, targetState)
+	expect(cc).toHaveLength(1)
+	expect(cc[0].cmds).toHaveLength(1)
+	expect(stripContext(cc[0].cmds[0])).toEqual(
+		fixCommand(
+			new AMCP.PlayCommand({
+				channel: 1,
+				layer: 10,
+				clip: 'AMB',
+				loop: false,
+				seek: 0
+			})
+		).serialize()
+	)
+})

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -90,6 +90,8 @@ export interface MediaLayer extends LayerBase, MediaLayerBase {
 	media: MediaLayerBase['media']
 	/** If the media is playing or not (is paused) */
 	playing: boolean
+	/** An id for the playback, to tell us to treat states with the same clip media as different */
+	playbackId?: string
 }
 export interface TemplateLayerBase {
 	/** Template name / file path */

--- a/src/lib/resolvers/background.ts
+++ b/src/lib/resolvers/background.ts
@@ -6,7 +6,9 @@ import {
 	NextUp,
 	HtmlPageLayer,
 	InputLayer,
-	RouteLayer
+	RouteLayer,
+	TransitionObject,
+	NextUpMedia
 } from '../api'
 import {
 	getLayer,
@@ -40,8 +42,8 @@ function diffBackground(oldState: InternalState, newState: State, channel: strin
 			newLayer.nextUp.content === LayerContentType.HTMLPAGE ||
 			newLayer.nextUp.content === LayerContentType.ROUTE
 		) {
-			const nl: MediaLayer = newLayer.nextUp as any
-			const ol: MediaLayer = oldLayer.nextUp as any
+			const nl: NextUpMedia = newLayer.nextUp as any
+			const ol: NextUpMedia = oldLayer.nextUp as any
 			setDefaultValue([nl, ol], ['auto'], false)
 			bgDiff = compareAttrs(nl, ol, ['auto', 'channelLayout'])
 		}
@@ -67,8 +69,8 @@ function diffBackground(oldState: InternalState, newState: State, channel: strin
 			oldLayer.nextUp &&
 			(typeof newLayer.nextUp.media !== 'string' || typeof oldLayer.nextUp.media !== 'string')
 		) {
-			const nMedia = newLayer.nextUp.media
-			const oMedia = oldLayer.nextUp.media
+			const nMedia = newLayer.nextUp.media as TransitionObject | undefined
+			const oMedia = oldLayer.nextUp.media as TransitionObject | undefined
 
 			bgDiff = compareAttrs(nMedia, oMedia, ['inTransition', 'outTransition', 'changeTransition'])
 		}
@@ -224,7 +226,7 @@ function resolveBackgroundState(
 					)
 				)
 			}
-		} else if (compareAttrs(oldLayer.nextUp, newLayer, ['media'])) {
+			// } else if (compareAttrs(oldLayer.nextUp, newLayer, ['media'])) {
 			// this.log('REMOVE BG')
 			// console.log('REMOVE BG', oldLayer.nextUp, newLayer)
 			// additionalCmds.push(new AMCP.LoadbgCommand({

--- a/src/lib/resolvers/empty.ts
+++ b/src/lib/resolvers/empty.ts
@@ -124,7 +124,11 @@ function resolveEmptyState(
 			}
 		}
 	}
-	if (oldLayer.nextUp && !newLayer.nextUp && compareAttrs(oldLayer.nextUp, newLayer, ['media'])) {
+	if (
+		oldLayer.nextUp &&
+		!newLayer.nextUp &&
+		compareAttrs<any>(oldLayer.nextUp, newLayer, ['media'])
+	) {
 		const prevClearCommand = _.find(diffCmds.cmds, (cmd) => {
 			return !!(cmd instanceof AMCP.ClearCommand) || cmd._commandName === 'ClearCommand'
 		})

--- a/src/lib/resolvers/foreground.ts
+++ b/src/lib/resolvers/foreground.ts
@@ -25,7 +25,8 @@ import {
 	FunctionLayer,
 	NextUp,
 	Transition,
-	TransitionObject
+	TransitionObject,
+	MediaLayerBase
 } from '../api'
 import { OptionsInterface, AMCPCommandVOWithContext, DiffCommands } from '../casparCGState'
 import { AMCP } from 'casparcg-connection'
@@ -160,7 +161,7 @@ function resolveForegroundState(
 
 				const timeSincePlay = getTimeSincePlay(nl, currentTime, minTimeSincePlay)
 
-				let diffMediaFromBg = compareAttrs(nl, ol.nextUp, ['media'])
+				let diffMediaFromBg = compareAttrs<MediaLayerBase>(nl, ol.nextUp, ['media'])
 				if (options.transition) {
 					diffMediaFromBg = 'transition'
 				} // transition changed, so we need to reset

--- a/src/lib/resolvers/foreground.ts
+++ b/src/lib/resolvers/foreground.ts
@@ -57,6 +57,7 @@ function diffForeground(
 				ol,
 				[
 					'media',
+					'playbackId',
 					'playTime',
 					'looping',
 					'seek',
@@ -191,7 +192,7 @@ function resolveForegroundState(
 				if (nl.playing) {
 					nl.pauseTime = 0
 
-					const newMedia = compareAttrs(nl, ol, ['media'])
+					const newMedia = compareAttrs(nl, ol, ['media', 'playbackId'])
 					const seekDiff = frames2TimeChannel(
 						Math.abs(oldSeekFrames - seekFrames),
 						newChannel,

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -148,10 +148,10 @@ export function fixPlayCommandInput<T extends object>(o: T): T {
 	}
 	return o2
 }
-export function compareAttrs(
-	obj0: any,
-	obj1: any,
-	attrs: Array<string>,
+export function compareAttrs<T extends { [key: string]: any }>(
+	obj0: T | undefined,
+	obj1: T | undefined,
+	attrs: Array<keyof T>,
 	minTimeSincePlay = 0.15, // [s]
 	strict?: boolean
 ): null | string {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

It is not possible to play the same clip on a layer immediately following itself with transitions.
The state resolver sees it as the same clip, just different properties so will treat it as a property change.

* **What is the new behavior (if this is a feature change)?**

The playbackId is included in the check for if the clip has changed, causing a full play command to be issues upon first seeing it.

* **Other information**:
