### PR TITLE
fix: remove casparcg-template media support for transitions

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -107,7 +107,7 @@ export interface TemplateLayerBase {
 }
 export interface TemplateLayer extends LayerBase, TemplateLayerBase {
 	content: LayerContentType.TEMPLATE
-	media: TemplateLayerBase['media']
+	media: string | null
 
 	/** [timestamp] If set, at what point in time the object started playing */
 	playTime: number | null


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix, bad typings.


* **What is the current behavior?** (You can also link to an open issue here)
Types say that the TEMPLATE `media: string | TransitionObject | null`. But a transition is actually not supported by CasparCG


* **What is the new behavior (if this is a feature change)?**
change type to  `media: string | null`


* **Other information**:
ref: https://github.com/nrkno/sofie-timeline-state-resolver/pull/225
